### PR TITLE
Upgrade to Rust 2018 edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ repository = "https://github.com/fralalonde/dipstick"
 readme = "README.md"
 keywords = ["metrics", "statsd", "graphite", "timer", "prometheus"]
 license = "MIT/Apache-2.0"
+edition = "2018"
 
 [badges]
 travis-ci = { repository = "fralalonde/dipstick", branch = "master" }

--- a/src/bucket/atomic.rs
+++ b/src/bucket/atomic.rs
@@ -1,14 +1,14 @@
 //! Maintain aggregated metrics for deferred reporting,
 
-use bucket::ScoreType::*;
-use bucket::{stats_summary, ScoreType};
-use core::attributes::{Attributes, Prefixed, WithAttributes};
-use core::clock::TimeHandle;
-use core::error;
-use core::input::{InputKind, InputMetric, InputScope};
-use core::name::MetricName;
-use core::output::{output_none, Output, OutputDyn, OutputMetric, OutputScope};
-use core::{Flush, MetricValue};
+use crate::bucket::ScoreType::*;
+use crate::bucket::{stats_summary, ScoreType};
+use crate::core::attributes::{Attributes, Prefixed, WithAttributes};
+use crate::core::clock::TimeHandle;
+use crate::core::error;
+use crate::core::input::{InputKind, InputMetric, InputScope};
+use crate::core::name::MetricName;
+use crate::core::output::{output_none, Output, OutputDyn, OutputMetric, OutputScope};
+use crate::core::{Flush, MetricValue};
 
 use std::collections::BTreeMap;
 use std::isize;
@@ -491,10 +491,10 @@ mod bench {
 #[cfg(test)]
 mod test {
     use super::*;
-    use bucket::{stats_all, stats_average, stats_summary};
+    use crate::bucket::{stats_all, stats_average, stats_summary};
 
-    use core::clock::{mock_clock_advance, mock_clock_reset};
-    use output::map::StatsMap;
+    use crate::core::clock::{mock_clock_advance, mock_clock_reset};
+    use crate::output::map::StatsMap;
 
     use std::collections::BTreeMap;
     use std::time::Duration;

--- a/src/bucket/mod.rs
+++ b/src/bucket/mod.rs
@@ -1,8 +1,8 @@
 pub mod atomic;
 
-use core::input::InputKind;
-use core::name::MetricName;
-use core::MetricValue;
+use crate::core::input::InputKind;
+use crate::core::name::MetricName;
+use crate::core::MetricValue;
 
 /// Possibly aggregated scores.
 #[derive(Debug, Clone, Copy)]

--- a/src/cache/cache_in.rs
+++ b/src/cache/cache_in.rs
@@ -1,11 +1,11 @@
 //! Metric input scope caching.
 
-use cache::lru_cache as lru;
-use core::attributes::{Attributes, Prefixed, WithAttributes};
-use core::error;
-use core::input::{Input, InputDyn, InputKind, InputMetric, InputScope};
-use core::name::MetricName;
-use core::Flush;
+use crate::cache::lru_cache as lru;
+use crate::core::attributes::{Attributes, Prefixed, WithAttributes};
+use crate::core::error;
+use crate::core::input::{Input, InputDyn, InputKind, InputMetric, InputScope};
+use crate::core::name::MetricName;
+use crate::core::Flush;
 
 use std::sync::Arc;
 

--- a/src/cache/cache_out.rs
+++ b/src/cache/cache_out.rs
@@ -1,12 +1,12 @@
 //! Metric output scope caching.
 
-use cache::lru_cache as lru;
-use core::attributes::{Attributes, Prefixed, WithAttributes};
-use core::error;
-use core::input::InputKind;
-use core::name::MetricName;
-use core::output::{Output, OutputDyn, OutputMetric, OutputScope};
-use core::Flush;
+use crate::cache::lru_cache as lru;
+use crate::core::attributes::{Attributes, Prefixed, WithAttributes};
+use crate::core::error;
+use crate::core::input::InputKind;
+use crate::core::name::MetricName;
+use crate::core::output::{Output, OutputDyn, OutputMetric, OutputScope};
+use crate::core::Flush;
 
 use std::sync::Arc;
 

--- a/src/core/attributes.rs
+++ b/src/core/attributes.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::default::Default;
 use std::sync::Arc;
 
-use core::name::{MetricName, NameParts};
+use crate::core::name::{MetricName, NameParts};
 
 /// The actual distribution (random, fixed-cycled, etc) depends on selected sampling method.
 #[derive(Debug, Clone, Copy)]

--- a/src/core/clock.rs
+++ b/src/core/clock.rs
@@ -6,7 +6,7 @@ use std::time::Duration;
 
 use std::time::Instant;
 
-use core::MetricValue;
+use crate::core::MetricValue;
 
 #[derive(Debug, Copy, Clone)]
 /// A handle to the start time of a counter.

--- a/src/core/input.rs
+++ b/src/core/input.rs
@@ -1,7 +1,7 @@
-use core::clock::TimeHandle;
-use core::label::Labels;
-use core::name::MetricName;
-use core::{Flush, MetricValue};
+use crate::core::clock::TimeHandle;
+use crate::core::label::Labels;
+use crate::core::name::MetricName;
+use crate::core::{Flush, MetricValue};
 
 use std::fmt;
 use std::sync::Arc;

--- a/src/core/locking.rs
+++ b/src/core/locking.rs
@@ -2,12 +2,12 @@
 //! This makes all outputs also immediately usable as inputs.
 //! The alternatives are queuing or thread local.
 
-use core::attributes::{Attributes, Prefixed, WithAttributes};
-use core::error;
-use core::input::{Input, InputKind, InputMetric, InputScope};
-use core::name::MetricName;
-use core::output::{Output, OutputScope};
-use core::Flush;
+use crate::core::attributes::{Attributes, Prefixed, WithAttributes};
+use crate::core::error;
+use crate::core::input::{Input, InputKind, InputMetric, InputScope};
+use crate::core::name::MetricName;
+use crate::core::output::{Output, OutputScope};
+use crate::core::Flush;
 use std::rc::Rc;
 
 use std::ops;

--- a/src/core/metrics.rs
+++ b/src/core/metrics.rs
@@ -2,9 +2,9 @@
 //! Because the possibly high volume of data, this is pre-set to use aggregation.
 //! This is also kept in a separate module because it is not to be exposed outside of the crate.
 
-use core::attributes::Prefixed;
-use core::input::{Counter, InputScope, Marker};
-use core::proxy::Proxy;
+use crate::core::attributes::Prefixed;
+use crate::core::input::{Counter, InputScope, Marker};
+use crate::core::proxy::Proxy;
 
 metrics! {
     /// Dipstick's own internal metrics.

--- a/src/core/output.rs
+++ b/src/core/output.rs
@@ -1,8 +1,8 @@
-use core::input::InputKind;
-use core::label::Labels;
-use core::name::MetricName;
-use core::void::Void;
-use core::{Flush, MetricValue};
+use crate::core::input::InputKind;
+use crate::core::label::Labels;
+use crate::core::name::MetricName;
+use crate::core::void::Void;
+use crate::core::{Flush, MetricValue};
 
 use std::rc::Rc;
 

--- a/src/core/pcg32.rs
+++ b/src/core/pcg32.rs
@@ -4,7 +4,7 @@
 #![cfg_attr(feature = "tool_lints", allow(clippy::unreadable_literal))]
 
 use std::cell::RefCell;
-use time;
+use crate::time;
 
 fn seed() -> u64 {
     let seed = 5573589319906701683_u64;

--- a/src/core/proxy.rs
+++ b/src/core/proxy.rs
@@ -1,11 +1,11 @@
 //! Decouple metric definition from configuration with trait objects.
 
-use core::attributes::{Attributes, Prefixed, WithAttributes};
-use core::error;
-use core::input::{InputKind, InputMetric, InputScope};
-use core::name::{MetricName, NameParts};
-use core::void::VOID_INPUT;
-use core::Flush;
+use crate::core::attributes::{Attributes, Prefixed, WithAttributes};
+use crate::core::error;
+use crate::core::input::{InputKind, InputMetric, InputScope};
+use crate::core::name::{MetricName, NameParts};
+use crate::core::void::VOID_INPUT;
+use crate::core::Flush;
 
 use std::collections::{BTreeMap, HashMap};
 use std::fmt;

--- a/src/core/scheduler.rs
+++ b/src/core/scheduler.rs
@@ -1,6 +1,6 @@
 //! Task scheduling facilities.
 
-use core::input::InputScope;
+use crate::core::input::InputScope;
 
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::Ordering::SeqCst;

--- a/src/core/void.rs
+++ b/src/core/void.rs
@@ -1,7 +1,7 @@
-use core::input::{InputDyn, InputKind, InputScope};
-use core::name::MetricName;
-use core::output::{Output, OutputMetric, OutputScope};
-use core::Flush;
+use crate::core::input::{InputDyn, InputKind, InputScope};
+use crate::core::name::MetricName;
+use crate::core::output::{Output, OutputMetric, OutputScope};
+use crate::core::Flush;
 
 use std::sync::Arc;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,7 +34,7 @@ extern crate parking_lot;
 
 #[macro_use]
 mod macros;
-pub use macros::*;
+pub use crate::macros::*;
 
 #[cfg(not(feature = "parking_lot"))]
 macro_rules! write_lock {
@@ -65,48 +65,48 @@ macro_rules! read_lock {
 }
 
 mod core;
-pub use core::attributes::{Buffered, Buffering, Prefixed, Sampled, Sampling};
-pub use core::clock::TimeHandle;
-pub use core::error::Result;
-pub use core::input::{
+pub use crate::core::attributes::{Buffered, Buffering, Prefixed, Sampled, Sampling};
+pub use crate::core::clock::TimeHandle;
+pub use crate::core::error::Result;
+pub use crate::core::input::{
     Counter, Gauge, Input, InputDyn, InputKind, InputMetric, InputScope, Level, Marker, Timer,
 };
-pub use core::label::{AppLabel, Labels, ThreadLabel};
-pub use core::locking::LockingOutput;
-pub use core::name::{MetricName, NameParts};
-pub use core::output::{Output, OutputDyn, OutputMetric, OutputScope};
-pub use core::scheduler::{CancelHandle, ScheduleFlush};
-pub use core::void::Void;
-pub use core::{Flush, MetricValue};
+pub use crate::core::label::{AppLabel, Labels, ThreadLabel};
+pub use crate::core::locking::LockingOutput;
+pub use crate::core::name::{MetricName, NameParts};
+pub use crate::core::output::{Output, OutputDyn, OutputMetric, OutputScope};
+pub use crate::core::scheduler::{CancelHandle, ScheduleFlush};
+pub use crate::core::void::Void;
+pub use crate::core::{Flush, MetricValue};
 
 #[cfg(test)]
-pub use core::clock::{mock_clock_advance, mock_clock_reset};
+pub use crate::core::clock::{mock_clock_advance, mock_clock_reset};
 
-pub use core::proxy::Proxy;
+pub use crate::core::proxy::Proxy;
 
 mod output;
-pub use output::format::{Formatting, LabelOp, LineFormat, LineOp, LineTemplate, SimpleFormat};
-pub use output::graphite::{Graphite, GraphiteMetric, GraphiteScope};
-pub use output::log::{Log, LogScope};
-pub use output::map::StatsMap;
-pub use output::statsd::{Statsd, StatsdMetric, StatsdScope};
-pub use output::stream::{Stream, TextScope};
+pub use crate::output::format::{Formatting, LabelOp, LineFormat, LineOp, LineTemplate, SimpleFormat};
+pub use crate::output::graphite::{Graphite, GraphiteMetric, GraphiteScope};
+pub use crate::output::log::{Log, LogScope};
+pub use crate::output::map::StatsMap;
+pub use crate::output::statsd::{Statsd, StatsdMetric, StatsdScope};
+pub use crate::output::stream::{Stream, TextScope};
 
 //#[cfg(feature="prometheus")]
-pub use output::prometheus::{Prometheus, PrometheusScope};
+pub use crate::output::prometheus::{Prometheus, PrometheusScope};
 
 mod bucket;
-pub use bucket::atomic::AtomicBucket;
-pub use bucket::{stats_all, stats_average, stats_summary, ScoreType};
+pub use crate::bucket::atomic::AtomicBucket;
+pub use crate::bucket::{stats_all, stats_average, stats_summary, ScoreType};
 
 mod cache;
-pub use cache::cache_in::CachedInput;
-pub use cache::cache_out::CachedOutput;
+pub use crate::cache::cache_in::CachedInput;
+pub use crate::cache::cache_out::CachedOutput;
 
 mod multi;
-pub use multi::multi_in::{MultiInput, MultiInputScope};
-pub use multi::multi_out::{MultiOutput, MultiOutputScope};
+pub use crate::multi::multi_in::{MultiInput, MultiInputScope};
+pub use crate::multi::multi_out::{MultiOutput, MultiOutputScope};
 
 mod queue;
-pub use queue::queue_in::{InputQueue, InputQueueScope, QueuedInput};
-pub use queue::queue_out::{OutputQueue, OutputQueueScope, QueuedOutput};
+pub use crate::queue::queue_in::{InputQueue, InputQueueScope, QueuedInput};
+pub use crate::queue::queue_out::{OutputQueue, OutputQueueScope, QueuedOutput};

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -52,7 +52,7 @@ macro_rules! labels {
             $(
                 let _ = _map.insert($key.into(), ::std::sync::Arc::new($value.into()));
             )*
-            ::Labels::from(_map)
+            crate::Labels::from(_map)
         }
     };
     () => {
@@ -167,8 +167,8 @@ macro_rules! metrics {
 
 #[cfg(test)]
 mod test {
-    use core::input::*;
-    use core::proxy::Proxy;
+    use crate::core::input::*;
+    use crate::core::proxy::Proxy;
 
     metrics! {TEST: Proxy = "test_prefix" => {
         pub M1: Marker = "failed";

--- a/src/multi/multi_in.rs
+++ b/src/multi/multi_in.rs
@@ -1,10 +1,10 @@
 //! Dispatch metrics to multiple sinks.
 
-use core::attributes::{Attributes, Prefixed, WithAttributes};
-use core::error;
-use core::input::{Input, InputDyn, InputKind, InputMetric, InputScope};
-use core::name::MetricName;
-use core::Flush;
+use crate::core::attributes::{Attributes, Prefixed, WithAttributes};
+use crate::core::error;
+use crate::core::input::{Input, InputDyn, InputKind, InputMetric, InputScope};
+use crate::core::name::MetricName;
+use crate::core::Flush;
 
 use std::sync::Arc;
 

--- a/src/multi/multi_out.rs
+++ b/src/multi/multi_out.rs
@@ -1,11 +1,11 @@
 //! Dispatch metrics to multiple sinks.
 
-use core::attributes::{Attributes, Prefixed, WithAttributes};
-use core::error;
-use core::input::InputKind;
-use core::name::MetricName;
-use core::output::{Output, OutputDyn, OutputMetric, OutputScope};
-use core::Flush;
+use crate::core::attributes::{Attributes, Prefixed, WithAttributes};
+use crate::core::error;
+use crate::core::input::InputKind;
+use crate::core::name::MetricName;
+use crate::core::output::{Output, OutputDyn, OutputMetric, OutputScope};
+use crate::core::Flush;
 
 use std::rc::Rc;
 use std::sync::Arc;

--- a/src/output/format.rs
+++ b/src/output/format.rs
@@ -1,7 +1,7 @@
 use self::LineOp::*;
-use core::input::InputKind;
-use core::name::MetricName;
-use core::MetricValue;
+use crate::core::input::InputKind;
+use crate::core::name::MetricName;
+use crate::core::MetricValue;
 
 use std::io;
 use std::sync::Arc;
@@ -110,7 +110,7 @@ impl LineFormat for SimpleFormat {
 #[cfg(test)]
 pub mod test {
     use super::*;
-    use core::label::Labels;
+    use crate::core::label::Labels;
 
     pub struct TestFormat;
 

--- a/src/output/graphite.rs
+++ b/src/output/graphite.rs
@@ -1,15 +1,15 @@
 //! Send metrics to a graphite server.
 
-use cache::cache_out;
-use core::attributes::{Attributes, Buffered, Prefixed, WithAttributes};
-use core::error;
-use core::input::InputKind;
-use core::metrics;
-use core::name::MetricName;
-use core::output::{Output, OutputMetric, OutputScope};
-use core::{Flush, MetricValue};
-use output::socket::RetrySocket;
-use queue::queue_out;
+use crate::cache::cache_out;
+use crate::core::attributes::{Attributes, Buffered, Prefixed, WithAttributes};
+use crate::core::error;
+use crate::core::input::InputKind;
+use crate::core::metrics;
+use crate::core::name::MetricName;
+use crate::core::output::{Output, OutputMetric, OutputScope};
+use crate::core::{Flush, MetricValue};
+use crate::output::socket::RetrySocket;
+use crate::queue::queue_out;
 
 use std::net::ToSocketAddrs;
 

--- a/src/output/log.rs
+++ b/src/output/log.rs
@@ -1,11 +1,11 @@
-use cache::cache_in;
-use core::attributes::{Attributes, Buffered, Prefixed, WithAttributes};
-use core::error;
-use core::input::{Input, InputKind, InputMetric, InputScope};
-use core::name::MetricName;
-use core::Flush;
-use output::format::{Formatting, LineFormat, SimpleFormat};
-use queue::queue_in;
+use crate::cache::cache_in;
+use crate::core::attributes::{Attributes, Buffered, Prefixed, WithAttributes};
+use crate::core::error;
+use crate::core::input::{Input, InputKind, InputMetric, InputScope};
+use crate::core::name::MetricName;
+use crate::core::Flush;
+use crate::output::format::{Formatting, LineFormat, SimpleFormat};
+use crate::queue::queue_in;
 
 use std::sync::Arc;
 
@@ -176,7 +176,7 @@ impl Drop for LogScope {
 
 #[cfg(test)]
 mod test {
-    use core::input::*;
+    use crate::core::input::*;
 
     #[test]
     fn test_to_log() {

--- a/src/output/map.rs
+++ b/src/output/map.rs
@@ -1,7 +1,7 @@
-use core::input::InputKind;
-use core::name::MetricName;
-use core::output::{OutputMetric, OutputScope};
-use core::{Flush, MetricValue};
+use crate::core::input::InputKind;
+use crate::core::name::MetricName;
+use crate::core::output::{OutputMetric, OutputScope};
+use crate::core::{Flush, MetricValue};
 
 use std::cell::RefCell;
 use std::collections::BTreeMap;

--- a/src/output/prometheus.rs
+++ b/src/output/prometheus.rs
@@ -1,15 +1,15 @@
 //! Send metrics to a Prometheus server.
 
-use cache::cache_out;
-use core::attributes::{Attributes, Buffered, Prefixed, WithAttributes};
-use core::error;
-use core::input::InputKind;
-use core::label::Labels;
-use core::metrics;
-use core::name::MetricName;
-use core::output::{Output, OutputMetric, OutputScope};
-use core::{Flush, MetricValue};
-use queue::queue_out;
+use crate::cache::cache_out;
+use crate::core::attributes::{Attributes, Buffered, Prefixed, WithAttributes};
+use crate::core::error;
+use crate::core::input::InputKind;
+use crate::core::label::Labels;
+use crate::core::metrics;
+use crate::core::name::MetricName;
+use crate::core::output::{Output, OutputMetric, OutputScope};
+use crate::core::{Flush, MetricValue};
+use crate::queue::queue_out;
 
 use std::cell::{RefCell, RefMut};
 use std::rc::Rc;

--- a/src/output/statsd.rs
+++ b/src/output/statsd.rs
@@ -1,15 +1,15 @@
 //! Send metrics to a statsd server.
 
-use cache::cache_out;
-use core::attributes::{Attributes, Buffered, Prefixed, Sampled, Sampling, WithAttributes};
-use core::error;
-use core::input::InputKind;
-use core::metrics;
-use core::name::MetricName;
-use core::output::{Output, OutputMetric, OutputScope};
-use core::pcg32;
-use core::{Flush, MetricValue};
-use queue::queue_out;
+use crate::cache::cache_out;
+use crate::core::attributes::{Attributes, Buffered, Prefixed, Sampled, Sampling, WithAttributes};
+use crate::core::error;
+use crate::core::input::InputKind;
+use crate::core::metrics;
+use crate::core::name::MetricName;
+use crate::core::output::{Output, OutputMetric, OutputScope};
+use crate::core::pcg32;
+use crate::core::{Flush, MetricValue};
+use crate::queue::queue_out;
 
 use std::cell::{RefCell, RefMut};
 use std::net::ToSocketAddrs;

--- a/src/output/stream.rs
+++ b/src/output/stream.rs
@@ -2,16 +2,16 @@
 
 // TODO parameterize templates
 
-use core::attributes::{Attributes, Buffered, Prefixed, WithAttributes};
-use core::error;
-use core::input::InputKind;
-use core::name::MetricName;
-use core::output::{Output, OutputMetric, OutputScope};
-use core::Flush;
+use crate::core::attributes::{Attributes, Buffered, Prefixed, WithAttributes};
+use crate::core::error;
+use crate::core::input::InputKind;
+use crate::core::name::MetricName;
+use crate::core::output::{Output, OutputMetric, OutputScope};
+use crate::core::Flush;
 
-use cache::cache_out;
-use output::format::{Formatting, LineFormat, SimpleFormat};
-use queue::queue_out;
+use crate::cache::cache_out;
+use crate::output::format::{Formatting, LineFormat, SimpleFormat};
+use crate::queue::queue_out;
 
 use std::cell::RefCell;
 use std::fs::File;
@@ -201,7 +201,7 @@ impl<W: Write + Send + Sync + 'static> Drop for TextScope<W> {
 #[cfg(test)]
 mod test {
     use super::*;
-    use core::input::InputKind;
+    use crate::core::input::InputKind;
     use std::io;
 
     #[test]

--- a/src/queue/queue_in.rs
+++ b/src/queue/queue_in.rs
@@ -2,14 +2,14 @@
 //! Metrics definitions are still synchronous.
 //! If queue size is exceeded, calling code reverts to blocking.
 
-use cache::cache_in::CachedInput;
-use core::attributes::{Attributes, Prefixed, WithAttributes};
-use core::error;
-use core::input::{Input, InputDyn, InputKind, InputMetric, InputScope};
-use core::label::Labels;
-use core::metrics;
-use core::name::MetricName;
-use core::{Flush, MetricValue};
+use crate::cache::cache_in::CachedInput;
+use crate::core::attributes::{Attributes, Prefixed, WithAttributes};
+use crate::core::error;
+use crate::core::input::{Input, InputDyn, InputKind, InputMetric, InputScope};
+use crate::core::label::Labels;
+use crate::core::metrics;
+use crate::core::name::MetricName;
+use crate::core::{Flush, MetricValue};
 
 #[cfg(not(feature = "crossbeam-channel"))]
 use std::sync::mpsc;

--- a/src/queue/queue_out.rs
+++ b/src/queue/queue_out.rs
@@ -2,15 +2,15 @@
 //! RawMetrics definitions are still synchronous.
 //! If queue size is exceeded, calling code reverts to blocking.
 
-use cache::cache_in;
-use core::attributes::{Attributes, Prefixed, WithAttributes};
-use core::error;
-use core::input::{Input, InputKind, InputMetric, InputScope};
-use core::label::Labels;
-use core::metrics;
-use core::name::MetricName;
-use core::output::{Output, OutputDyn, OutputMetric, OutputScope};
-use core::{Flush, MetricValue};
+use crate::cache::cache_in;
+use crate::core::attributes::{Attributes, Prefixed, WithAttributes};
+use crate::core::error;
+use crate::core::input::{Input, InputKind, InputMetric, InputScope};
+use crate::core::label::Labels;
+use crate::core::metrics;
+use crate::core::name::MetricName;
+use crate::core::output::{Output, OutputDyn, OutputMetric, OutputScope};
+use crate::core::{Flush, MetricValue};
 
 use std::fmt;
 use std::ops;


### PR DESCRIPTION
Run `cargo fmt` to format code
Run `cargo fix --edition` to update crate for rust 2018
Specify edition to 2018 in Cargo.toml
closes #47 