### PR TITLE
Reexport `ObserveWhen` to make it public.

### DIFF
--- a/src/core/attributes.rs
+++ b/src/core/attributes.rs
@@ -114,6 +114,7 @@ where
     }
 }
 
+/// When to observe a recurring task.
 pub struct ObserveWhen<'a, T, F> {
     target: &'a T,
     metric: InputMetric,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,7 +63,9 @@ macro_rules! read_lock {
 }
 
 mod core;
-pub use core::attributes::{Buffered, Buffering, Observe, OnFlush, Prefixed, Sampled, Sampling};
+pub use core::attributes::{
+    Buffered, Buffering, Observe, ObserveWhen, OnFlush, Prefixed, Sampled, Sampling,
+};
 pub use core::clock::TimeHandle;
 pub use core::error::Result;
 pub use core::input::{


### PR DESCRIPTION
- `ObserveWhen` is a return value of public `Observe.observe()` but it is unfortunately private.