### PR TITLE
Allow delegating the Observe trait to other type

### DIFF
--- a/src/core/attributes.rs
+++ b/src/core/attributes.rs
@@ -146,18 +146,24 @@ where
 
 /// Schedule a recurring task
 pub trait Observe {
+    /// The inner type for the [`ObserveWhen`].
+    ///
+    /// The observe can be delegated to a different type then `Self`, however the latter is more
+    /// common.
+    type Inner;
     /// Provide a source for a metric's values.
     fn observe<F>(
         &self,
         metric: impl Deref<Target = InputMetric>,
         operation: F,
-    ) -> ObserveWhen<Self, F>
+    ) -> ObserveWhen<Self::Inner, F>
     where
         F: Fn(Instant) -> MetricValue + Send + Sync + 'static,
         Self: Sized;
 }
 
 impl<T: InputScope + WithAttributes> Observe for T {
+    type Inner = Self;
     fn observe<F>(
         &self,
         metric: impl Deref<Target = InputMetric>,


### PR DESCRIPTION
When the result was fixed to ObserveWhen<Self, _>, it was impossible to
simply delegate the trait into an wrapped type. This allows the
possibility to return ObserveWhen<Whatever, _> (which can be Self in the
case of the default implementation).

Fixes #65.

While this is not strictly semver-compatible change, since an implementer of the trait will get the error of not all trait items being implemented. I however think it is practically so, whoever might have attempted to implement the trait would have hit the problem in #65 so I don't think there are to be any implementers of that trait in the wild.