### PR TITLE
Make OnFlushCancel public

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,7 +53,7 @@ macro_rules! read_lock {
 
 mod core;
 pub use crate::core::attributes::{
-    Buffered, Buffering, Observe, ObserveWhen, OnFlush, Prefixed, Sampled, Sampling,
+    Buffered, Buffering, Observe, ObserveWhen, OnFlush, OnFlushCancel, Prefixed, Sampled, Sampling,
 };
 pub use crate::core::clock::TimeHandle;
 pub use crate::core::error::Result;


### PR DESCRIPTION
Otherwise it can't be directly stored into a struct, because the type
can't be named.

Slightly related, isn't there a clippy warning that could prevent these things from happening?