### PR TITLE
Use must_use on the ObserveWhen

### DIFF
--- a/src/core/attributes.rs
+++ b/src/core/attributes.rs
@@ -197,6 +197,7 @@ pub trait Observe {
     /// common.
     type Inner;
     /// Provide a source for a metric's values.
+    #[must_use = "must specify when to observe"]
     fn observe<F>(
         &self,
         metric: impl Deref<Target = InputMetric>,


### PR DESCRIPTION
Otherwise, nothing would get observed, so better warn on it.