### PR TITLE
Make the OnFlushCancel Send and Sync

### DIFF
--- a/src/core/attributes.rs
+++ b/src/core/attributes.rs
@@ -140,7 +140,7 @@ pub struct ObserveWhen<'a, T, F> {
 static ID_GENERATOR: AtomicUsize = AtomicUsize::new(0);
 
 /// A handle to cancel a flush observer.
-pub struct OnFlushCancel(Arc<dyn Fn()>);
+pub struct OnFlushCancel(Arc<dyn Fn() + Send + Sync>);
 
 impl Cancel for OnFlushCancel {
     fn cancel(&self) {


### PR DESCRIPTION
It is useless otherwise in most multithreaded applications.

If this is OK, could I ask for a release as well? Thanks.