### PR TITLE
Exposed attributes::MetricId to make extending new outputs possible

### DIFF
--- a/examples/basics.rs
+++ b/examples/basics.rs
@@ -45,6 +45,6 @@ fn main() {
 
     // using a "time handle"
     let start_time = timer.start();
-    Duration::from_millis(5);
+    sleep(Duration::from_millis(5));
     timer.stop(start_time);
 }

--- a/examples/raw_log.rs
+++ b/examples/raw_log.rs
@@ -1,7 +1,7 @@
 //! Use the metrics backend directly to log a metric value.
 //! Applications should use the metrics()-provided instruments instead.
 
-use dipstick::{labels, Input, InputScope, Labels};
+use dipstick::{labels, Input, InputScope};
 
 fn main() {
     raw_write()

--- a/src/attributes.rs
+++ b/src/attributes.rs
@@ -59,10 +59,12 @@ impl Default for Buffering {
     }
 }
 
+/// A metrics identifier
 #[derive(Clone, Debug, Hash, Eq, PartialOrd, PartialEq)]
 pub struct MetricId(String);
 
 impl MetricId {
+    /// Return a MetricId based on output type and metric name
     pub fn forge(out_type: &str, name: MetricName) -> Self {
         let id: String = name.join("/");
         MetricId(format!("{}:{}", out_type, id))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,7 +71,8 @@ mod multi;
 mod queue;
 
 pub use crate::attributes::{
-    Buffered, Buffering, Observe, ObserveWhen, OnFlush, OnFlushCancel, Prefixed, Sampled, Sampling,
+    Buffered, Buffering, MetricId, Observe, ObserveWhen, OnFlush, OnFlushCancel, Prefixed, Sampled,
+    Sampling,
 };
 pub use crate::clock::TimeHandle;
 pub use crate::input::{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,8 +71,8 @@ mod multi;
 mod queue;
 
 pub use crate::attributes::{
-    Buffered, Buffering, MetricId, Observe, ObserveWhen, OnFlush, OnFlushCancel, Prefixed, Sampled,
-    Sampling,
+    Attributes, Buffered, Buffering, MetricId, Observe, ObserveWhen, OnFlush, OnFlushCancel,
+    Prefixed, Sampled, Sampling, WithAttributes,
 };
 pub use crate::clock::TimeHandle;
 pub use crate::input::{


### PR DESCRIPTION
Fixes #85

- Made attributes::MetricId public 
- Tagalong: fixed some warnings in examples.